### PR TITLE
fix(discord): bust cached logo URLs

### DIFF
--- a/src/careers_engine/company/logos.py
+++ b/src/careers_engine/company/logos.py
@@ -11,4 +11,4 @@ def get_logo_url(company: str) -> str | None:
     if slug is None:
         return None
 
-    return f"{LOGO_BASE_URL}/{slug}.png"
+    return f"{LOGO_BASE_URL}/{slug}.png?v=2"


### PR DESCRIPTION
temporarily modified `get_logo_url()` for testing cache busting to fetch the latest refreshed logo url