### PR TITLE
feat(employment): normalize manual employment types

### DIFF
--- a/.github/workflows/queue_opportunity.yml
+++ b/.github/workflows/queue_opportunity.yml
@@ -1,4 +1,4 @@
-name: Queue Manual Opportunity
+name: Queue Opportunity
 
 on:
   workflow_dispatch:
@@ -28,6 +28,7 @@ on:
           - Internship
           - New Grad
           - Full Time
+          - Apprenticeship
 
       priority:
         description: Priority

--- a/scripts/queue_opportunity.py
+++ b/scripts/queue_opportunity.py
@@ -3,8 +3,38 @@ from __future__ import annotations
 import os
 
 from careers_engine.config import QUEUE_FILE
-from careers_engine.models import Job
+from careers_engine.models import EmploymentType, Job
 from careers_engine.storage import JobDatabase
+
+EMPLOYMENT_TYPE_ALIASES = {
+    "internship": EmploymentType.INTERN,
+    "new grad": EmploymentType.NEW_GRAD,
+    "graduate": EmploymentType.NEW_GRAD,
+    "full time": EmploymentType.FULL_TIME,
+    "full-time": EmploymentType.FULL_TIME,
+    "fulltime": EmploymentType.FULL_TIME,
+    "contract": EmploymentType.CONTRACT,
+    "contractor": EmploymentType.CONTRACT,
+    "part time": EmploymentType.PART_TIME,
+    "part-time": EmploymentType.PART_TIME,
+    "apprenticeship": EmploymentType.APPRENTICESHIP,
+}
+
+
+def parse_employment_type(value: str) -> EmploymentType:
+    """Normalize user input into a supported employment type."""
+
+    key = value.strip().lower()
+
+    try:
+        return EMPLOYMENT_TYPE_ALIASES[key]
+    except KeyError as exc:
+        raise ValueError(
+            "Unsupported employment type: "
+            f"{value!r}. "
+            "Supported values include: Internship, New Grad, "
+            "Full Time, Part Time, Contract, Apprenticeship."
+        ) from exc
 
 
 def optional(value: str | None) -> str | None:
@@ -37,7 +67,7 @@ def main() -> None:
         role=getenv("ROLE"),
         location=getenv("LOCATION"),
         apply_url=getenv("APPLY_URL"),
-        employment_type=getenv("EMPLOYMENT_TYPE"),
+        employment_type=parse_employment_type(getenv("EMPLOYMENT_TYPE")),
         priority=getenv("PRIORITY"),
         deadline=optional(os.getenv("DEADLINE")),
         stipend=optional(os.getenv("STIPEND")),

--- a/src/careers_engine/models/enums.py
+++ b/src/careers_engine/models/enums.py
@@ -3,6 +3,8 @@ from enum import Enum
 
 class EmploymentType(str, Enum):
     INTERN = "Internship"
+    NEW_GRAD = "New Grad"
+    APPRENTICESHIP = "Apprenticeship"
     FULL_TIME = "Full-time"
     PART_TIME = "Part-time"
     CONTRACT = "Contract"


### PR DESCRIPTION
earlier it raised value error for mismatch role type:
as expected `Full-time` instead of `Full Time`, similarly for `New Grad`.

hence
- normalizing his mismatch throughout
- and introduce `Apprenticeship` in role type
- update value error output on mismatch for better clarity