### PR TITLE
feat(employment): centralize employment type handling

### DIFF
--- a/scripts/queue_opportunity.py
+++ b/scripts/queue_opportunity.py
@@ -3,38 +3,9 @@ from __future__ import annotations
 import os
 
 from careers_engine.config import QUEUE_FILE
-from careers_engine.models import EmploymentType, Job
+from careers_engine.employment import parse_employment_type
+from careers_engine.models import Job
 from careers_engine.storage import JobDatabase
-
-EMPLOYMENT_TYPE_ALIASES = {
-    "internship": EmploymentType.INTERN,
-    "new grad": EmploymentType.NEW_GRAD,
-    "graduate": EmploymentType.NEW_GRAD,
-    "full time": EmploymentType.FULL_TIME,
-    "full-time": EmploymentType.FULL_TIME,
-    "fulltime": EmploymentType.FULL_TIME,
-    "contract": EmploymentType.CONTRACT,
-    "contractor": EmploymentType.CONTRACT,
-    "part time": EmploymentType.PART_TIME,
-    "part-time": EmploymentType.PART_TIME,
-    "apprenticeship": EmploymentType.APPRENTICESHIP,
-}
-
-
-def parse_employment_type(value: str) -> EmploymentType:
-    """Normalize user input into a supported employment type."""
-
-    key = value.strip().lower()
-
-    try:
-        return EMPLOYMENT_TYPE_ALIASES[key]
-    except KeyError as exc:
-        raise ValueError(
-            "Unsupported employment type: "
-            f"{value!r}. "
-            "Supported values include: Internship, New Grad, "
-            "Full Time, Part Time, Contract, Apprenticeship."
-        ) from exc
 
 
 def optional(value: str | None) -> str | None:

--- a/src/careers_engine/employment.py
+++ b/src/careers_engine/employment.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from careers_engine.models import EmploymentType
+
+EMPLOYMENT_TYPE_ALIASES = {
+    "intern": EmploymentType.INTERN,
+    "internship": EmploymentType.INTERN,
+    "new grad": EmploymentType.NEW_GRAD,
+    "graduate": EmploymentType.NEW_GRAD,
+    "full time": EmploymentType.FULL_TIME,
+    "full-time": EmploymentType.FULL_TIME,
+    "fulltime": EmploymentType.FULL_TIME,
+    "part time": EmploymentType.PART_TIME,
+    "part-time": EmploymentType.PART_TIME,
+    "contract": EmploymentType.CONTRACT,
+    "contractor": EmploymentType.CONTRACT,
+    "fixed term": EmploymentType.CONTRACT,
+    "apprentice": EmploymentType.APPRENTICESHIP,
+    "apprenticeship": EmploymentType.APPRENTICESHIP,
+}
+
+
+INTERNSHIP_KEYWORDS = (
+    "intern",
+    "internship",
+    "summer intern",
+    "summer internship",
+)
+
+NEW_GRAD_KEYWORDS = (
+    "new grad",
+    "graduate",
+    "campus",
+    "university graduate",
+    "university hire",
+    "early career",
+    "entry level",
+)
+
+APPRENTICESHIP_KEYWORDS = (
+    "apprentice",
+    "apprenticeship",
+)
+
+CONTRACT_KEYWORDS = (
+    "contract",
+    "contractor",
+    "fixed term",
+    "temporary",
+)
+
+
+def parse_employment_type(value: str) -> EmploymentType:
+    """Normalize user input into a supported employment type."""
+
+    key = value.strip().lower()
+
+    try:
+        return EMPLOYMENT_TYPE_ALIASES[key]
+
+    except KeyError as exc:
+        raise ValueError(
+            "Unsupported employment type: "
+            f"{value!r}. "
+            "Supported values include: Internship, New Grad, "
+            "Full Time, Part Time, Contract, Apprenticeship."
+        ) from exc
+
+
+def infer_employment_type(role: str) -> EmploymentType:
+    """Infer the employment type from a job title."""
+
+    role = role.lower()
+
+    if any(keyword in role for keyword in INTERNSHIP_KEYWORDS):
+        return EmploymentType.INTERN
+
+    if any(keyword in role for keyword in NEW_GRAD_KEYWORDS):
+        return EmploymentType.NEW_GRAD
+
+    if any(keyword in role for keyword in APPRENTICESHIP_KEYWORDS):
+        return EmploymentType.APPRENTICESHIP
+
+    if any(keyword in role for keyword in CONTRACT_KEYWORDS):
+        return EmploymentType.CONTRACT
+
+    return EmploymentType.FULL_TIME

--- a/src/careers_engine/sources/upstream.py
+++ b/src/careers_engine/sources/upstream.py
@@ -5,6 +5,7 @@ from careers_engine.config import (
     UPSTREAM_FILES,
     UPSTREAM_REPOSITORY,
 )
+from careers_engine.employment import infer_employment_type
 from careers_engine.models import Job
 from careers_engine.parsers import MarkdownTableParser
 from careers_engine.sources.base import BaseSource
@@ -41,6 +42,7 @@ class UpstreamSource(BaseSource):
                         role=row["role"],
                         location=row["location"],
                         apply_url=row["posting"],
+                        employment_type=infer_employment_type(row["role"]),
                     )
                 )
 

--- a/tests/test_employment.py
+++ b/tests/test_employment.py
@@ -1,0 +1,93 @@
+import pytest
+
+from careers_engine.employment import (
+    infer_employment_type,
+    parse_employment_type,
+)
+from careers_engine.models import EmploymentType
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("Internship", EmploymentType.INTERN),
+        ("internship", EmploymentType.INTERN),
+        ("New Grad", EmploymentType.NEW_GRAD),
+        ("graduate", EmploymentType.NEW_GRAD),
+        ("Full Time", EmploymentType.FULL_TIME),
+        ("full-time", EmploymentType.FULL_TIME),
+        ("fulltime", EmploymentType.FULL_TIME),
+        ("Part Time", EmploymentType.PART_TIME),
+        ("part-time", EmploymentType.PART_TIME),
+        ("Contract", EmploymentType.CONTRACT),
+        ("contractor", EmploymentType.CONTRACT),
+        ("Apprenticeship", EmploymentType.APPRENTICESHIP),
+        ("apprentice", EmploymentType.APPRENTICESHIP),
+    ],
+)
+def test_parse_employment_type(value: str, expected: EmploymentType) -> None:
+    assert parse_employment_type(value) == expected
+
+
+def test_parse_employment_type_invalid() -> None:
+    with pytest.raises(
+        ValueError,
+        match="Unsupported employment type",
+    ):
+        parse_employment_type("Volunteer")
+
+
+@pytest.mark.parametrize(
+    ("role", "expected"),
+    [
+        (
+            "Software Engineer Intern",
+            EmploymentType.INTERN,
+        ),
+        (
+            "Backend Engineering Internship",
+            EmploymentType.INTERN,
+        ),
+        (
+            "Software Engineer - New Grad",
+            EmploymentType.NEW_GRAD,
+        ),
+        (
+            "Graduate Software Engineer",
+            EmploymentType.NEW_GRAD,
+        ),
+        (
+            "Software Development Apprenticeship",
+            EmploymentType.APPRENTICESHIP,
+        ),
+        (
+            "Apprentice Software Engineer",
+            EmploymentType.APPRENTICESHIP,
+        ),
+        (
+            "Backend Engineer (Contract)",
+            EmploymentType.CONTRACT,
+        ),
+        (
+            "Software Engineer Contractor",
+            EmploymentType.CONTRACT,
+        ),
+        (
+            "Software Engineer",
+            EmploymentType.FULL_TIME,
+        ),
+        (
+            "Senior Software Engineer",
+            EmploymentType.FULL_TIME,
+        ),
+        (
+            "Staff Software Engineer",
+            EmploymentType.FULL_TIME,
+        ),
+    ],
+)
+def test_infer_employment_type(
+    role: str,
+    expected: EmploymentType,
+) -> None:
+    assert infer_employment_type(role) == expected


### PR DESCRIPTION
previously all job posts on dc were using only `Internship` Role Type
so introduce {Employment type inference} which will be appllied for newly collected jobs

## changes
- introduce dedicated `employment.py` module
- move manual employment type parsing into shared utility
- infer employment types for upstream jobs from their respective titles
- add test for parsing and inference