### PR TITLE
docs: add other directories and files to avoid 404 from sidebar

### DIFF
--- a/docs/api/discord.mdx
+++ b/docs/api/discord.mdx
@@ -1,0 +1,8 @@
+---
+title: "Discord"
+description: "Discord publishing API reference."
+---
+
+Documentation for this section is currently under development.
+
+This page will document the Discord client, formatter, and publisher components.

--- a/docs/api/models.mdx
+++ b/docs/api/models.mdx
@@ -1,0 +1,8 @@
+---
+title: "Models"
+description: "Data model reference."
+---
+
+Documentation for this section is currently under development.
+
+This page will document the core data models used across careers-engine.

--- a/docs/api/parsers.mdx
+++ b/docs/api/parsers.mdx
@@ -1,0 +1,8 @@
+---
+title: "Parsers"
+description: "Parser API reference."
+---
+
+Documentation for this section is currently under development.
+
+This page will document the parser interfaces and helpers used to extract opportunities from source content.

--- a/docs/api/sources.mdx
+++ b/docs/api/sources.mdx
@@ -1,0 +1,8 @@
+---
+title: "Sources"
+description: "Source integration API reference."
+---
+
+Documentation for this section is currently under development.
+
+This page will document the source abstractions used to fetch and normalize job listings.

--- a/docs/api/storage.mdx
+++ b/docs/api/storage.mdx
@@ -1,0 +1,8 @@
+---
+title: "Storage"
+description: "Storage API reference."
+---
+
+Documentation for this section is currently under development.
+
+This page will document the storage helpers and interfaces used to persist job data.

--- a/docs/architecture/company-branding.mdx
+++ b/docs/architecture/company-branding.mdx
@@ -1,0 +1,8 @@
+---
+title: "Company Branding"
+description: "Applying company-specific branding."
+---
+
+Documentation for this section is currently under development.
+
+This page will explain how careers-engine resolves company names, logos, and visual metadata before publishing.

--- a/docs/architecture/employment-inference.mdx
+++ b/docs/architecture/employment-inference.mdx
@@ -1,0 +1,8 @@
+---
+title: "Employment Inference"
+description: "How careers-engine classifies employment type."
+---
+
+Documentation for this section is currently under development.
+
+This page will explain how careers-engine infers whether a role is internship, new grad, or full time.

--- a/docs/architecture/ingestion-pipeline.mdx
+++ b/docs/architecture/ingestion-pipeline.mdx
@@ -1,0 +1,8 @@
+---
+title: "Ingestion Pipeline"
+description: "How careers-engine collects opportunities."
+---
+
+Documentation for this section is currently under development.
+
+This page will explain how careers-engine fetches source data, parses job listings, and normalizes records before storage.

--- a/docs/architecture/overview.mdx
+++ b/docs/architecture/overview.mdx
@@ -1,0 +1,8 @@
+---
+title: "Overview"
+description: "Architecture overview."
+---
+
+Documentation for this section is currently under development.
+
+This page will explain the high-level flow of careers-engine, from source collection through enrichment, storage, and publishing.

--- a/docs/architecture/publishing-pipeline.mdx
+++ b/docs/architecture/publishing-pipeline.mdx
@@ -1,0 +1,8 @@
+---
+title: "Publishing Pipeline"
+description: "How careers-engine publishes opportunities."
+---
+
+Documentation for this section is currently under development.
+
+This page will explain how new opportunities are detected, formatted, and published to Discord.

--- a/docs/architecture/repository-layout.mdx
+++ b/docs/architecture/repository-layout.mdx
@@ -1,0 +1,8 @@
+---
+title: "Repository Layout"
+description: "Project structure and responsibilities."
+---
+
+Documentation for this section is currently under development.
+
+This page will explain how the repository is organized and which parts of the codebase own each responsibility.

--- a/docs/architecture/storage.mdx
+++ b/docs/architecture/storage.mdx
@@ -1,0 +1,8 @@
+---
+title: "Storage"
+description: "Persistent storage for job data."
+---
+
+Documentation for this section is currently under development.
+
+This page will explain how careers-engine stores jobs, tracks history, and versions data in the companion careers-data repository.

--- a/docs/developer-guide/adding-company.mdx
+++ b/docs/developer-guide/adding-company.mdx
@@ -1,0 +1,14 @@
+---
+title: "Adding a Company"
+description: "Add a company."
+---
+
+This guide is currently under development.
+
+It will cover:
+
+- Company metadata
+- Branding
+- Career page configuration
+- Validation
+- Testing

--- a/docs/developer-guide/adding-employment-rule.mdx
+++ b/docs/developer-guide/adding-employment-rule.mdx
@@ -1,0 +1,8 @@
+---
+title: "Adding an Employment Rule"
+description: "Add an employment inference rule."
+---
+
+Documentation for this section is currently under development.
+
+This page will explain how to add or refine rules that classify internships, new grad roles, and full-time roles.

--- a/docs/developer-guide/adding-logo.mdx
+++ b/docs/developer-guide/adding-logo.mdx
@@ -1,0 +1,8 @@
+---
+title: "Adding a Logo"
+description: "Add a company logo."
+---
+
+Documentation for this section is currently under development.
+
+This page will explain how to provide, validate, and reference company logos in careers-engine.

--- a/docs/developer-guide/adding-source.mdx
+++ b/docs/developer-guide/adding-source.mdx
@@ -1,0 +1,8 @@
+---
+title: "Adding a Source"
+description: "Add a new job source."
+---
+
+Documentation for this section is currently under development.
+
+This guide will cover source registration, parsing rules, validation, and testing for new job sources.

--- a/docs/developer-guide/contributing.mdx
+++ b/docs/developer-guide/contributing.mdx
@@ -1,0 +1,8 @@
+---
+title: "Contributing"
+description: "How to contribute to careers-engine."
+---
+
+Documentation for this section is currently under development.
+
+This page will explain the contribution workflow, code standards, and review expectations for careers-engine.

--- a/docs/developer-guide/release-process.mdx
+++ b/docs/developer-guide/release-process.mdx
@@ -1,0 +1,8 @@
+---
+title: "Release Process"
+description: "How careers-engine changes are released."
+---
+
+Documentation for this section is currently under development.
+
+This page will explain how releases are prepared, validated, and published for careers-engine.

--- a/docs/developer-guide/testing.mdx
+++ b/docs/developer-guide/testing.mdx
@@ -1,0 +1,8 @@
+---
+title: "Testing"
+description: "How to test careers-engine changes."
+---
+
+Documentation for this section is currently under development.
+
+This page will explain the test suite, common validation steps, and how to verify changes locally.

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -1,0 +1,8 @@
+---
+title: "CLI"
+description: "Command line interface reference."
+---
+
+Documentation for this section is currently under development.
+
+This page will document the available commands, flags, and usage patterns for the careers-engine CLI.

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -1,0 +1,8 @@
+---
+title: "Configuration"
+description: "Project configuration reference."
+---
+
+Documentation for this section is currently under development.
+
+This page will document the configuration values used to run and customize careers-engine.

--- a/docs/reference/environment-variables.mdx
+++ b/docs/reference/environment-variables.mdx
@@ -1,0 +1,8 @@
+---
+title: "Environment Variables"
+description: "Environment variables reference."
+---
+
+Documentation for this section is currently under development.
+
+This page will document the environment variables used by the CLI, automation, and publishing workflows.

--- a/docs/reference/json-schema.mdx
+++ b/docs/reference/json-schema.mdx
@@ -1,0 +1,8 @@
+---
+title: "JSON Schema"
+description: "Data schema reference."
+---
+
+Documentation for this section is currently under development.
+
+This page will document the JSON schema used for jobs, history, and other structured data files.

--- a/docs/reference/workflows.mdx
+++ b/docs/reference/workflows.mdx
@@ -1,0 +1,8 @@
+---
+title: "Workflows"
+description: "Automation workflow reference."
+---
+
+Documentation for this section is currently under development.
+
+This page will document the GitHub Actions workflows that run collection, publishing, and related maintenance tasks.


### PR DESCRIPTION
earlier, we had navigation from sidebar for expected doc files
but as these files weren't created so it was giving `404 error`

hence create those respective files with placeholder text, to avoid 404