### PR TITLE
ci: add Docs Deployment Tracker workflow for staging - docs environment

### DIFF
--- a/.github/workflows/docs-deployment.yml
+++ b/.github/workflows/docs-deployment.yml
@@ -1,0 +1,22 @@
+name: Docs Deployment Tracker
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *" # scheduling so it automatically fetches, without manual trigger
+
+permissions:
+  contents: read
+  deployments: write
+
+concurrency:
+  group: docs-deployment
+  cancel-in-progress: true
+
+jobs:
+  record:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Tracking Mintlify docs deployment"
+    environment:
+      name: staging - docs
+      url: https://careers-engine.zenyukti.in


### PR DESCRIPTION
adds a minimal GitHub Actions workflow to register the `staging - docs` environment

this ensures Mintlify deployments are surfaced in the GitHub sidebar under "Deployments"
alongside Releases. No code changes or redeployments are performed

### target exp:

<img width="306" height="273" alt="image" src="https://github.com/user-attachments/assets/d0ccde91-b76b-4b9e-9f03-1bf49d98272f" />

### currently

<img width="367" height="453" alt="image" src="https://github.com/user-attachments/assets/bc9d12f8-45a3-43b9-a7e1-17115142084a" />

