### PR TITLE
feat(discord): restrict bot to a configured guild (server)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,8 @@
 DISCORD_TOKEN=  
 DISCORD_CHANNEL_ID=
+# Discord server (guild) ID
+DISCORD_GUILD_ID=
 
-# todo: to get these values follow the instructions given in docs
+DATA_DIR=
+
+# TODO: to get these values follow the instructions given in docs

--- a/docs/getting-started/configuration.mdx
+++ b/docs/getting-started/configuration.mdx
@@ -54,8 +54,16 @@ The project requires several environment variables to access external services a
 DISCORD_TOKEN=...
 DISCORD_CHANNEL_ID=...
 
+DISCORD_GUILD_ID=...
+
 DATA_DIR=../careers-data
 ```
+<Card type="warning" title="Single Server Deployment">
+-
+`DISCORD_GUILD_ID` restricts the bot to a single Discord server. If the bot joins any other server, it automatically leaves and publishes opportunities only to the configured guild.
+</Card>
+
+{/* (-) before the `DISCORD_BUILD_ID` is used for one line ga between titl and content, veirfied using `mint dev` */}
 
 Additional variables may be required depending on the workflow being executed.
 
@@ -74,8 +82,9 @@ workspace/
 │   └── src/
 │
 └── careers-data/
-    ├── data/
-    ├── queue/
+    ├── data.json
+    ├── queue.json
+    ├── history.json
     └── ...
 ```
 

--- a/src/careers_engine/config.py
+++ b/src/careers_engine/config.py
@@ -39,6 +39,9 @@ DISCORD_TOKEN = os.environ.get("DISCORD_TOKEN", "")
 
 DISCORD_CHANNEL_ID = int(os.environ.get("DISCORD_CHANNEL_ID", "0"))
 
+# Restrict publishing to a single Discord server
+DISCORD_GUILD_ID = int(os.environ.get("DISCORD_GUILD_ID", "0"))
+
 # to be updated, when fetch_logos.py is run and assets/logos directory is updated
 # i.e) new version ro new images are downloaded
 # syntax: 1.0 -> 2.0 -> 3.0 -> 4.0... so on

--- a/src/careers_engine/discord/client.py
+++ b/src/careers_engine/discord/client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import discord
 
-from careers_engine.config import DISCORD_CHANNEL_ID, DISCORD_TOKEN, DISCORD_GUILD_ID
+from careers_engine.config import DISCORD_CHANNEL_ID, DISCORD_GUILD_ID, DISCORD_TOKEN
 from careers_engine.discord.publisher import DiscordPublisher
 from careers_engine.models import Job
 
@@ -21,20 +21,16 @@ class DiscordClient(discord.Client):
         # clean up existing guilds
         for guild in self.guilds:
             if guild.id != DISCORD_GUILD_ID:
-                print(
-                    f"Leaving unauthorized guild: "
-                    f"{guild.name} ({guild.id})"
-                )
+                print(f"Leaving unauthorized guild: {guild.name} ({guild.id})")
 
                 await guild.leave()
 
-        guild = self.get_guild(DISCORD_GUILD_ID)
-        if guild is None:
-            raise RuntimeError(
-                "Configured Discord guild not found."
-            )
+        target_guild = self.get_guild(DISCORD_GUILD_ID)
 
-        channel = guild.get_channel(DISCORD_CHANNEL_ID)
+        if target_guild is None:
+            raise RuntimeError("Configured Discord guild not found.")
+
+        channel = target_guild.get_channel(DISCORD_CHANNEL_ID)
 
         if not isinstance(channel, discord.TextChannel):
             raise RuntimeError("Configured Discord channel not found.")
@@ -49,16 +45,13 @@ class DiscordClient(discord.Client):
         """Leave unauthorized guilds."""
 
         if guild.id != DISCORD_GUILD_ID:
-            print(
-                f"Leaving unauthorized guild "
-                f"{guild.name} ({guild.id})"
-            )
+            print(f"Leaving unauthorized guild {guild.name} ({guild.id})")
 
             await guild.leave()
 
     async def start_client(self) -> None:
         """Start the Discord client."""
-        
+
         if DISCORD_GUILD_ID == 0:
             raise RuntimeError("DISCORD_GUILD_ID is not configured.")
 

--- a/src/careers_engine/discord/client.py
+++ b/src/careers_engine/discord/client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import discord
 
-from careers_engine.config import DISCORD_CHANNEL_ID, DISCORD_TOKEN
+from careers_engine.config import DISCORD_CHANNEL_ID, DISCORD_TOKEN, DISCORD_GUILD_ID
 from careers_engine.discord.publisher import DiscordPublisher
 from careers_engine.models import Job
 
@@ -18,7 +18,22 @@ class DiscordClient(discord.Client):
     async def on_ready(self) -> None:
         print(f"Logged in as {self.user}")
 
-        guild = self.guilds[0]
+        # clean up existing guilds
+        for guild in self.guilds:
+            if guild.id != DISCORD_GUILD_ID:
+                print(
+                    f"Leaving unauthorized guild: "
+                    f"{guild.name} ({guild.id})"
+                )
+
+                await guild.leave()
+
+        guild = self.get_guild(DISCORD_GUILD_ID)
+        if guild is None:
+            raise RuntimeError(
+                "Configured Discord guild not found."
+            )
+
         channel = guild.get_channel(DISCORD_CHANNEL_ID)
 
         if not isinstance(channel, discord.TextChannel):
@@ -30,6 +45,24 @@ class DiscordClient(discord.Client):
 
         await self.close()
 
+    async def on_guild_join(self, guild: discord.Guild) -> None:
+        """Leave unauthorized guilds."""
+
+        if guild.id != DISCORD_GUILD_ID:
+            print(
+                f"Leaving unauthorized guild "
+                f"{guild.name} ({guild.id})"
+            )
+
+            await guild.leave()
+
     async def start_client(self) -> None:
         """Start the Discord client."""
+        
+        if DISCORD_GUILD_ID == 0:
+            raise RuntimeError("DISCORD_GUILD_ID is not configured.")
+
+        if DISCORD_CHANNEL_ID == 0:
+            raise RuntimeError("DISCORD_CHANNEL_ID is not configured.")
+
         await self.start(DISCORD_TOKEN)


### PR DESCRIPTION
this change introduces `DISCORD_GUILD_ID` (`.env`) nd ensures the bot only operates within the configured Discord server

## Changes

- add `DISCORD_GUILD_ID` configuration
- validate Discord configuration before starting the client
- replace `self.guilds[0]` with an explicit guild lookup
- Automatically leave unauthorized guilds
- update `.env.example` & other documentation of Configurations
- Clarify the expected `careers-data` directory structure

## why

the bot is intended to publish opportunities only within the configured ZenYukti Discord server...

this prevents accidental deployment or publishing to unauthorized Discord servers while keeping the bot publicly installable for future use cases